### PR TITLE
fix: use supported Cloudflare Pages pagination

### DIFF
--- a/.github/workflows/commons-release.yml
+++ b/.github/workflows/commons-release.yml
@@ -89,7 +89,7 @@ jobs:
               curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
                 --connect-timeout 10 --max-time 30 --max-filesize 1048576 \
                 --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-                "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/marginal-commons/deployments?env=production&per_page=100&page=${deployment_page}" \
+                "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/marginal-commons/deployments?env=production&per_page=25&page=${deployment_page}" \
                 --output current/deployments.json
               total_pages="$(DEPLOYMENT_PAGE="${deployment_page}" python - <<'PY'
           import json

--- a/tests/commons/test_release_workflow.py
+++ b/tests/commons/test_release_workflow.py
@@ -99,5 +99,7 @@ def test_unsigned_bootstrap_checks_all_production_deployment_pages() -> None:
     )
     command = compare["run"]
     assert "page=${deployment_page}" in command
+    assert "per_page=25" in command
+    assert "per_page=100" not in command
     assert "total_pages" in command
     assert "deployment_page=$((deployment_page + 1))" in command


### PR DESCRIPTION
Cloudflare Pages deployment history rejects `per_page=100` with error 8000024.

Confirmed against the production API:
- `per_page=100` -> HTTP 400
- `per_page=25` -> HTTP 200

This changes the signed Commons bootstrap history pagination to 25 and adds a regression assertion.

Verification:
- 6 release-workflow tests passed
- Ruff passed
- git diff --check passed