### PR TITLE
ci: Pin GitHub Actions to immutable SHAs to prevent supply chain risks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,8 +16,8 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      - uses: github/codeql-action/init@4c0873ef8656cb3c50b3f42fb63bc1ade0cfa827
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@4c0873ef8656cb3c50b3f42fb63bc1ade0cfa827

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
       - name: Assemble website
         shell: bash
         run: |
@@ -52,7 +52,7 @@ jobs:
           test -f _site/demo/demo.css
           test -f _site/demo/demo.js
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: _site
 
@@ -65,4 +65,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.13"
           cache: pip

--- a/.github/workflows/swebench-lite-canary.yml
+++ b/.github/workflows/swebench-lite-canary.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.11"
           cache: pip
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload benchmark evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: swebench-lite-${{ inputs.task_set }}-${{ github.run_id }}
           if-no-files-found: warn

--- a/tests/evaluation/test_swebench_lite_workflow.py
+++ b/tests/evaluation/test_swebench_lite_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -19,7 +20,8 @@ def test_workflow_is_manual_modal_only_and_compares_both_lanes() -> None:
     assert "marginal_predictions.ndjson" in text
     assert text.count("--modal true") == 2
     assert "marginal public-eval" in text
-    assert "actions/upload-artifact@v7" in text
+    assert not re.search(r"actions/upload-artifact@v\d+", text)
+    assert re.search(r"actions/upload-artifact@[0-9a-f]{40}", text)
 
 
 def test_readme_refuses_gold_as_marginal_evidence() -> None:


### PR DESCRIPTION
Hey! 👋 I was exploring Marginal (the Claude Code integration looks super interesting!) and I ran the repository through a security and architecture scanner we are building called [VibeMass](https://vibemass.com). 

I noticed a minor supply-chain vulnerability in your CI/CD workflows, so I wanted to quickly patch it for you.

### 1. Security Fix: Mutable GitHub Action Tags
Workflows like `ci.yml`, `codeql.yml`, `release.yml`, and `swebench-lite-canary.yml` were using mutable tags like `@v6` and `@v4`. If any of those upstream action repositories are ever compromised, an attacker could silently inject malware into your builds. 
**Fix:** I’ve pinned your GitHub Actions to their exact 40-character commit SHAs to guarantee supply chain security.

### 2. Architecture Heads-Up (No Action Required)
As a side note, the scanner's Architecture agent flagged a few heavy "God Files" that might become bottlenecks as you scale:
- `src/marginal/privacy.py` and `src/marginal/governance_ledger.py` are getting massive. The agent flagged that having all privacy and governance logic centralized in single files makes it much harder to audit for compliance and adapt to new regulations without risking side effects across the whole system. 
- It also flagged `src/marginal/integrations/codex/service.py` as a monolithic service that might slow down feature velocity.

Just wanted to leave that as a helpful architectural breadcrumb. Keep up the great work on the project! 🚀
